### PR TITLE
Remove skip for mock_in_unit_test, specify test dir

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal=1
+
+[nosetests]
+tests=src/azure_devtools/scenario_tests/tests

--- a/src/azure_devtools/scenario_tests/patches.py
+++ b/src/azure_devtools/scenario_tests/patches.py
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import unittest
-
 from .exceptions import AzureTestError
 
 
@@ -24,7 +22,6 @@ def patch_long_run_operation_delay(unit_test):
                       _shortcut_long_run_operation)
 
 
-@unittest.skip("this is a helper, not a unit test")
 def mock_in_unit_test(unit_test, target, replacement):
     import mock
     import unittest


### PR DESCRIPTION
Using `@unittest.skip` on `mock_in_unit_test` prevented it from being incorrectly treated as a unit test by nose, but also caused (some?) tests that used it to get skipped. This fixes that by removing the decorator and instead specifying the test directory in `setup.cfg`.