### PR TITLE
Access token processor

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import io
 from setuptools import setup
 
 
-VERSION = "0.4.1"
+VERSION = "0.4.3"
 
 
 CLASSIFIERS = [

--- a/src/azure_devtools/scenario_tests/__init__.py
+++ b/src/azure_devtools/scenario_tests/__init__.py
@@ -11,7 +11,7 @@ from .preparers import AbstractPreparer, SingleValueReplacer
 from .recording_processors import (
     RecordingProcessor, SubscriptionRecordingProcessor,
     LargeRequestBodyProcessor, LargeResponseBodyProcessor, LargeResponseBodyReplacer,
-    OAuthRequestResponsesFilter, DeploymentNameReplacer, GeneralNameReplacer,
+    OAuthRequestResponsesFilter, DeploymentNameReplacer, GeneralNameReplacer, AccessTokenReplacer,
 )
 from .utilities import create_random_name, get_sha1_hash
 
@@ -22,6 +22,7 @@ __all__ = ['IntegrationTestBase', 'ReplayableTest', 'LiveTest',
            'RecordingProcessor', 'SubscriptionRecordingProcessor',
            'LargeRequestBodyProcessor', 'LargeResponseBodyProcessor', 'LargeResponseBodyReplacer',
            'OAuthRequestResponsesFilter', 'DeploymentNameReplacer', 'GeneralNameReplacer',
+           'AccessTokenReplacer',
            'live_only', 'record_only',
            'create_random_name', 'get_sha1_hash']
-__version__ = '0.4.1'
+__version__ = '0.4.3'

--- a/src/azure_devtools/scenario_tests/recording_processors.py
+++ b/src/azure_devtools/scenario_tests/recording_processors.py
@@ -127,6 +127,22 @@ class DeploymentNameReplacer(RecordingProcessor):
         return request
 
 
+class AccessTokenReplacer(RecordingProcessor):
+    """Replace the access token for service principal authentication in a response body."""
+    def __init__(self, replacement='fake_token'):
+        self._replacement = replacement
+
+    def process_response(self, response):
+        import json
+        try:
+            body = json.loads(response['body']['string'])
+            body['access_token'] = self._replacement
+        except (KeyError, ValueError):
+            return response
+        response['body']['string'] = json.dumps(body)
+        return response
+
+
 class GeneralNameReplacer(RecordingProcessor):
     def __init__(self):
         self.names_name = []


### PR DESCRIPTION
This `RecordingProcessor` subclass is needed in Azure sample code since we expect it to be run using a service principal. It removes the access token from the body of the response provided by the server upon authentication.