### PR TITLE
Fix mapping of boolean record_mode to underlying vcr modes

### DIFF
--- a/src/azure_devtools/scenario_tests/base.py
+++ b/src/azure_devtools/scenario_tests/base.py
@@ -106,7 +106,7 @@ class ReplayableTest(IntegrationTestBase):  # pylint: disable=too-many-instance-
             before_record_request=self._process_request_recording,
             before_record_response=self._process_response_recording,
             decode_compressed_response=True,
-            record_mode=self.config.record_mode,
+            record_mode='all' if self.config.record_mode else 'once',
             filter_headers=self.FILTER_HEADERS
         )
         self.vcr.register_matcher('query', self._custom_request_query_matcher)


### PR DESCRIPTION
This PR fixes #21 by passing an appropriate string for `VCR()`'s `record_mode` parameter rather than a boolean like it was doing before.