### PR TITLE
Fix subscription id removal

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ CLASSIFIERS = [
 DEPENDENCIES = [
     'ConfigArgParse>=0.12.0',
     'six>=1.10.0',
-    'vcrpy>=1.11.1',
+    'vcrpy>=1.11.0',
 ]
 
 with io.open('README.rst', 'r', encoding='utf-8') as f:

--- a/src/azure_devtools/scenario_tests/tests/test_recording_processor.py
+++ b/src/azure_devtools/scenario_tests/tests/test_recording_processor.py
@@ -49,7 +49,8 @@ class TestRecordingProcessors(unittest.TestCase):
         no_token_response_sample = {'body': {'string': '{"location": "westus"}'}}
         self.assertDictEqual(rp.process_response(no_token_response_sample), no_token_response_sample)
 
-    def _mock_subscription_request_body(self, mock_sub_id):
+    @staticmethod
+    def _mock_subscription_request_body(mock_sub_id):
         return json.dumps({
             "location": "westus",
             "properties": {


### PR DESCRIPTION
This PR fixes #16 and #23, to ensure that subscription ID is correctly removed in all cases that `SubscriptionRecordingProcessor` purports to address.

I recommend a new release (0.5.0, probably, since this changes the behavior) after this is merged. Failing to remove the subscription ID seems like a significant problem.