### PR TITLE
Fix recordmode

### DIFF
--- a/src/azure_devtools/scenario_tests/base.py
+++ b/src/azure_devtools/scenario_tests/base.py
@@ -106,7 +106,7 @@ class ReplayableTest(IntegrationTestBase):  # pylint: disable=too-many-instance-
             before_record_request=self._process_request_recording,
             before_record_response=self._process_response_recording,
             decode_compressed_response=True,
-            record_mode=self.config.record_mode,
+            record_mode='once' if not self.is_live else 'all',
             filter_headers=self.FILTER_HEADERS
         )
         self.vcr.register_matcher('query', self._custom_request_query_matcher)

--- a/src/azure_devtools/scenario_tests/tests/test_config.py
+++ b/src/azure_devtools/scenario_tests/tests/test_config.py
@@ -29,8 +29,8 @@ class TestScenarioConfig(unittest.TestCase):
     def test_env_var(self):
         with mock.patch.dict('os.environ', {ENV_LIVE_TEST: 'yes'}):
             config = TestConfig()
-        self.assertTrue(config.record_mode)
+        self.assertIs(config.record_mode, True)
 
     def test_config_file(self):
         config = TestConfig(config_file=self.cfgfile)
-        self.assertTrue(config.record_mode)
+        self.assertIs(config.record_mode, True)

--- a/src/azure_devtools/scenario_tests/tests/test_config.py
+++ b/src/azure_devtools/scenario_tests/tests/test_config.py
@@ -7,7 +7,10 @@ import os
 import tempfile
 import unittest
 
-import mock
+try:
+    import mock
+except ImportError:
+    from unittest import mock
 
 
 from azure_devtools.scenario_tests.const import ENV_LIVE_TEST


### PR DESCRIPTION
@troydai I just realize that at some point we stopped passing a string to record_mode, but passing a boolean! Therefore `config.record_mode` is just a True/False about "is this live mode or not". and this is what we give to VCR....

VCRPy never check that value directly, but just do test like `record_mode == 'all'` or `record_mode!='once'`, it's a miracle this was able to record something... And this is most likely the cause of my SDK issue in [this exact test](https://github.com/kevin1024/vcrpy/blob/v1.11.1/vcr/cassette.py#L246).

I'm going to do more extensive tests with the SDK, but wanted to open the PR right now for discussion.