### PR TITLE
url parsing fix to account for different urls in versions of python plus import fix

### DIFF
--- a/src/azure_devtools/scenario_tests/__init__.py
+++ b/src/azure_devtools/scenario_tests/__init__.py
@@ -11,7 +11,7 @@ from .preparers import AbstractPreparer, SingleValueReplacer
 from .recording_processors import (
     RecordingProcessor, SubscriptionRecordingProcessor,
     LargeRequestBodyProcessor, LargeResponseBodyProcessor, LargeResponseBodyReplacer,
-    OAuthRequestResponsesFilter, DeploymentNameReplacer, GeneralNameReplacer, AccessTokenReplacer,
+    OAuthRequestResponsesFilter, DeploymentNameReplacer, GeneralNameReplacer, AccessTokenReplacer, SlashReplacer,
 )
 from .utilities import create_random_name, get_sha1_hash
 
@@ -22,7 +22,7 @@ __all__ = ['IntegrationTestBase', 'ReplayableTest', 'LiveTest',
            'RecordingProcessor', 'SubscriptionRecordingProcessor',
            'LargeRequestBodyProcessor', 'LargeResponseBodyProcessor', 'LargeResponseBodyReplacer',
            'OAuthRequestResponsesFilter', 'DeploymentNameReplacer', 'GeneralNameReplacer',
-           'AccessTokenReplacer',
+           'AccessTokenReplacer', 'SlashReplacer',
            'live_only', 'record_only',
            'create_random_name', 'get_sha1_hash']
 __version__ = '0.5.0'

--- a/src/azure_devtools/scenario_tests/__init__.py
+++ b/src/azure_devtools/scenario_tests/__init__.py
@@ -11,7 +11,7 @@ from .preparers import AbstractPreparer, SingleValueReplacer
 from .recording_processors import (
     RecordingProcessor, SubscriptionRecordingProcessor,
     LargeRequestBodyProcessor, LargeResponseBodyProcessor, LargeResponseBodyReplacer,
-    OAuthRequestResponsesFilter, DeploymentNameReplacer, GeneralNameReplacer, AccessTokenReplacer, SlashReplacer,
+    OAuthRequestResponsesFilter, DeploymentNameReplacer, GeneralNameReplacer, AccessTokenReplacer, RequestUrlNormalizer,
 )
 from .utilities import create_random_name, get_sha1_hash
 
@@ -22,7 +22,7 @@ __all__ = ['IntegrationTestBase', 'ReplayableTest', 'LiveTest',
            'RecordingProcessor', 'SubscriptionRecordingProcessor',
            'LargeRequestBodyProcessor', 'LargeResponseBodyProcessor', 'LargeResponseBodyReplacer',
            'OAuthRequestResponsesFilter', 'DeploymentNameReplacer', 'GeneralNameReplacer',
-           'AccessTokenReplacer', 'SlashReplacer',
+           'AccessTokenReplacer', 'RequestUrlNormalizer',
            'live_only', 'record_only',
            'create_random_name', 'get_sha1_hash']
 __version__ = '0.5.0'

--- a/src/azure_devtools/scenario_tests/base.py
+++ b/src/azure_devtools/scenario_tests/base.py
@@ -10,7 +10,6 @@ import inspect
 import tempfile
 import shutil
 import logging
-import re
 import six
 import vcr
 
@@ -143,11 +142,6 @@ class ReplayableTest(IntegrationTestBase):  # pylint: disable=too-many-instance-
         os.environ = self.original_env
 
     def _process_request_recording(self, request):
-        # URL parsing fix to account for '//' vs '/' in different versions of python
-        # - Python 2.7 for 2.7/3.3/3.4 (...Microsoft.Compute//availabilitySets...)
-        # - Python 3.5 (...Microsoft.Compute/availabilitySets...)
-        request.uri = re.sub('(?<!:)//', '/', request.uri)
-
         if self.disable_recording:
             return None
 

--- a/src/azure_devtools/scenario_tests/base.py
+++ b/src/azure_devtools/scenario_tests/base.py
@@ -12,6 +12,7 @@ import shutil
 import logging
 import six
 import vcr
+import re
 
 from .config import TestConfig
 from .const import ENV_TEST_DIAGNOSE
@@ -142,6 +143,11 @@ class ReplayableTest(IntegrationTestBase):  # pylint: disable=too-many-instance-
         os.environ = self.original_env
 
     def _process_request_recording(self, request):
+        # URL parsing fix to account for '//' vs '/' in different versions of python
+        # - Python 2.7 for 2.7/3.3/3.4 (...Microsoft.Compute//availabilitySets...)
+        # - Python 3.5 (...Microsoft.Compute/availabilitySets...)
+        request.uri = re.sub('(?<!:)//', '/', request.uri)
+
         if self.disable_recording:
             return None
 

--- a/src/azure_devtools/scenario_tests/base.py
+++ b/src/azure_devtools/scenario_tests/base.py
@@ -10,9 +10,9 @@ import inspect
 import tempfile
 import shutil
 import logging
+import re
 import six
 import vcr
-import re
 
 from .config import TestConfig
 from .const import ENV_TEST_DIAGNOSE

--- a/src/azure_devtools/scenario_tests/patches.py
+++ b/src/azure_devtools/scenario_tests/patches.py
@@ -23,7 +23,10 @@ def patch_long_run_operation_delay(unit_test):
 
 
 def mock_in_unit_test(unit_test, target, replacement):
-    import mock
+    try:
+        import unittest.mock as mock
+    except ImportError:
+        import mock
     import unittest
 
     if not isinstance(unit_test, unittest.TestCase):

--- a/src/azure_devtools/scenario_tests/recording_processors.py
+++ b/src/azure_devtools/scenario_tests/recording_processors.py
@@ -177,7 +177,7 @@ class GeneralNameReplacer(RecordingProcessor):
         return response
 
 
-class SlashReplacer(RecordingProcessor):
+class RequestUrlNormalizer(RecordingProcessor):
     """URL parsing fix to account for '//' vs '/' in different versions of python"""
     def process_request(self, request):
         import re

--- a/src/azure_devtools/scenario_tests/recording_processors.py
+++ b/src/azure_devtools/scenario_tests/recording_processors.py
@@ -175,3 +175,11 @@ class GeneralNameReplacer(RecordingProcessor):
             self.replace_header(response, 'azure-asyncoperation', old, new)
 
         return response
+
+
+class SlashReplacer(RecordingProcessor):
+    """URL parsing fix to account for '//' vs '/' in different versions of python"""
+    def process_request(self, request):
+        import re
+        request.uri = re.sub('(?<!:)//', '/', request.uri)
+        return request


### PR DESCRIPTION
-added same fix from sdk to python devtools
-subs `//` for `/` in middle of url
