### PR TITLE
Detect leaked LRO poller

### DIFF
--- a/src/azure_devtools/scenario_tests/base.py
+++ b/src/azure_devtools/scenario_tests/base.py
@@ -141,7 +141,8 @@ class ReplayableTest(IntegrationTestBase):  # pylint: disable=too-many-instance-
 
     def tearDown(self):
         os.environ = self.original_env
-        assert not [t for t in threading.enumerate() if t.name.startswith("AzureOperationPoller")]
+        assert not [t for t in threading.enumerate() if t.name.startswith("AzureOperationPoller")], \
+            "You need to call 'result' or 'wait' on all AzureOperationPoller you have created"
 
     def _process_request_recording(self, request):
         if self.disable_recording:

--- a/src/azure_devtools/scenario_tests/base.py
+++ b/src/azure_devtools/scenario_tests/base.py
@@ -10,8 +10,8 @@ import inspect
 import tempfile
 import shutil
 import logging
-import six
 import threading
+import six
 import vcr
 
 from .config import TestConfig

--- a/src/azure_devtools/scenario_tests/base.py
+++ b/src/azure_devtools/scenario_tests/base.py
@@ -11,6 +11,7 @@ import tempfile
 import shutil
 import logging
 import six
+import threading
 import vcr
 
 from .config import TestConfig
@@ -140,6 +141,7 @@ class ReplayableTest(IntegrationTestBase):  # pylint: disable=too-many-instance-
 
     def tearDown(self):
         os.environ = self.original_env
+        assert not [t for t in threading.enumerate() if t.name.startswith("AzureOperationPoller")]
 
     def _process_request_recording(self, request):
         if self.disable_recording:


### PR DESCRIPTION
Tested for non-regression here (everything is fine except KV because of msrest 0.4.15...):
https://travis-ci.org/lmazuel/azure-sdk-for-python/builds/282822484

Tested for behavior here (this Travis should be red with this message from here):
https://travis-ci.org/lmazuel/azure-sdk-for-python/builds/282836037

The choice of assert is on purpose, since `assert` makes the test to fail, and not to be in error:
https://docs.python.org/3/library/unittest.html#unittest.TestCase.tearDown