### PR TITLE
Support playback with binary and large response payload

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 codecov==2.0.9
 mock==2.0.0;python_version<="2.7"
 nose==1.3.7
-pylint==1.7.1
+pylint==1.8.2
 
 -e .

--- a/src/azure_devtools/scenario_tests/__init__.py
+++ b/src/azure_devtools/scenario_tests/__init__.py
@@ -11,7 +11,6 @@ from .preparers import AbstractPreparer, SingleValueReplacer
 from .recording_processors import (
     RecordingProcessor, SubscriptionRecordingProcessor,
     LargeRequestBodyProcessor, LargeResponseBodyProcessor, LargeResponseBodyReplacer,
-    BinaryResponseBodyProcessor, BinaryResponseBodyFixer,
     OAuthRequestResponsesFilter, DeploymentNameReplacer, GeneralNameReplacer, AccessTokenReplacer, RequestUrlNormalizer,
 )
 from .utilities import create_random_name, get_sha1_hash
@@ -22,7 +21,6 @@ __all__ = ['IntegrationTestBase', 'ReplayableTest', 'LiveTest',
            'AbstractPreparer', 'SingleValueReplacer',
            'RecordingProcessor', 'SubscriptionRecordingProcessor',
            'LargeRequestBodyProcessor', 'LargeResponseBodyProcessor', 'LargeResponseBodyReplacer',
-           'BinaryResponseBodyProcessor', 'BinaryResponseBodyFixer',
            'OAuthRequestResponsesFilter', 'DeploymentNameReplacer', 'GeneralNameReplacer',
            'AccessTokenReplacer', 'RequestUrlNormalizer',
            'live_only', 'record_only',

--- a/src/azure_devtools/scenario_tests/__init__.py
+++ b/src/azure_devtools/scenario_tests/__init__.py
@@ -11,6 +11,7 @@ from .preparers import AbstractPreparer, SingleValueReplacer
 from .recording_processors import (
     RecordingProcessor, SubscriptionRecordingProcessor,
     LargeRequestBodyProcessor, LargeResponseBodyProcessor, LargeResponseBodyReplacer,
+    BinaryResponseBodyProcessor, BinaryResponseBodyFixer,
     OAuthRequestResponsesFilter, DeploymentNameReplacer, GeneralNameReplacer, AccessTokenReplacer, RequestUrlNormalizer,
 )
 from .utilities import create_random_name, get_sha1_hash
@@ -21,6 +22,7 @@ __all__ = ['IntegrationTestBase', 'ReplayableTest', 'LiveTest',
            'AbstractPreparer', 'SingleValueReplacer',
            'RecordingProcessor', 'SubscriptionRecordingProcessor',
            'LargeRequestBodyProcessor', 'LargeResponseBodyProcessor', 'LargeResponseBodyReplacer',
+           'BinaryResponseBodyProcessor', 'BinaryResponseBodyFixer',
            'OAuthRequestResponsesFilter', 'DeploymentNameReplacer', 'GeneralNameReplacer',
            'AccessTokenReplacer', 'RequestUrlNormalizer',
            'live_only', 'record_only',

--- a/src/azure_devtools/scenario_tests/__init__.py
+++ b/src/azure_devtools/scenario_tests/__init__.py
@@ -7,7 +7,7 @@ from .base import IntegrationTestBase, ReplayableTest, LiveTest
 from .exceptions import AzureTestError
 from .decorators import live_only, record_only
 from .patches import mock_in_unit_test, patch_time_sleep_api, patch_long_run_operation_delay
-from .preparers import AbstractPreparer, SingleValueReplacer
+from .preparers import AbstractPreparer, SingleValueReplacer, AllowLargeResponse
 from .recording_processors import (
     RecordingProcessor, SubscriptionRecordingProcessor,
     LargeRequestBodyProcessor, LargeResponseBodyProcessor, LargeResponseBodyReplacer,
@@ -18,7 +18,7 @@ from .utilities import create_random_name, get_sha1_hash
 __all__ = ['IntegrationTestBase', 'ReplayableTest', 'LiveTest',
            'AzureTestError',
            'mock_in_unit_test', 'patch_time_sleep_api', 'patch_long_run_operation_delay',
-           'AbstractPreparer', 'SingleValueReplacer',
+           'AbstractPreparer', 'SingleValueReplacer', 'AllowLargeResponse',
            'RecordingProcessor', 'SubscriptionRecordingProcessor',
            'LargeRequestBodyProcessor', 'LargeResponseBodyProcessor', 'LargeResponseBodyReplacer',
            'OAuthRequestResponsesFilter', 'DeploymentNameReplacer', 'GeneralNameReplacer',

--- a/src/azure_devtools/scenario_tests/base.py
+++ b/src/azure_devtools/scenario_tests/base.py
@@ -162,6 +162,7 @@ class ReplayableTest(IntegrationTestBase):  # pylint: disable=too-many-instance-
         return request
 
     def _process_response_recording(self, response):
+        from .utilities import is_text_payload
         if self.in_recording:
             # make header name lower case and filter unwanted headers
             headers = {}
@@ -171,11 +172,8 @@ class ReplayableTest(IntegrationTestBase):  # pylint: disable=too-many-instance-
             response['headers'] = headers
 
             body = response['body']['string']
-            if body and not isinstance(body, six.string_types):
-                try:
-                    response['body']['string'] = body.decode('utf-8')
-                except ValueError:
-                    pass
+            if is_text_payload(response) and body and not isinstance(body, six.string_types):
+                response['body']['string'] = body.decode('utf-8')
 
             for processor in self.recording_processors:
                 response = processor.process_response(response)

--- a/src/azure_devtools/scenario_tests/base.py
+++ b/src/azure_devtools/scenario_tests/base.py
@@ -172,7 +172,10 @@ class ReplayableTest(IntegrationTestBase):  # pylint: disable=too-many-instance-
 
             body = response['body']['string']
             if body and not isinstance(body, six.string_types):
-                response['body']['string'] = body.decode('utf-8')
+                try:
+                    response['body']['string'] = body.decode('utf-8')
+                except ValueError:
+                    pass
 
             for processor in self.recording_processors:
                 response = processor.process_response(response)

--- a/src/azure_devtools/scenario_tests/preparers.py
+++ b/src/azure_devtools/scenario_tests/preparers.py
@@ -129,6 +129,20 @@ class SingleValueReplacer(RecordingProcessor):
         return response
 
 
+# Function wise, enabling large payload recording has nothing to do with resource preparers
+# We still base on it so that this decorator can chain with other preparers w/o too much hacks
+class AllowLargeResponse(AbstractPreparer):
+    def __init__(self, size_kb=1024):
+        self.size_kb = size_kb
+        super(AllowLargeResponse, self).__init__('nanana', 20)
+
+    def create_resource(self, _, **kwargs):
+        from azure_devtools.scenario_tests import LargeResponseBodyProcessor
+        large_resp_body = next((r for r in self.test_class_instance.recording_processors
+                                if isinstance(r, LargeResponseBodyProcessor)), None)
+        if large_resp_body:
+            large_resp_body._max_response_body = self.size_kb  # pylint: disable=protected-access
+
 # Utility
 
 def is_preparer_func(fn):

--- a/src/azure_devtools/scenario_tests/preparers.py
+++ b/src/azure_devtools/scenario_tests/preparers.py
@@ -8,7 +8,7 @@ import inspect
 import functools
 
 from .base import ReplayableTest
-from .utilities import create_random_name
+from .utilities import create_random_name, is_text_payload
 from .recording_processors import RecordingProcessor
 
 
@@ -111,7 +111,7 @@ class SingleValueReplacer(RecordingProcessor):
             request.uri = request.uri.replace(quote_plus(self.random_name),
                                               quote_plus(self.moniker))
 
-        if self.is_text_payload(request) and request.body:
+        if is_text_payload(request) and request.body:
             body = str(request.body)
             if self.random_name in body:
                 request.body = body.replace(self.random_name, self.moniker)
@@ -119,7 +119,7 @@ class SingleValueReplacer(RecordingProcessor):
         return request
 
     def process_response(self, response):
-        if self.is_text_payload(response) and response['body']['string']:
+        if is_text_payload(response) and response['body']['string']:
             response['body']['string'] = response['body']['string'].replace(self.random_name,
                                                                             self.moniker)
 

--- a/src/azure_devtools/scenario_tests/preparers.py
+++ b/src/azure_devtools/scenario_tests/preparers.py
@@ -111,7 +111,7 @@ class SingleValueReplacer(RecordingProcessor):
             request.uri = request.uri.replace(quote_plus(self.random_name),
                                               quote_plus(self.moniker))
 
-        if request.body:
+        if self.is_text_payload(request) and request.body:
             body = str(request.body)
             if self.random_name in body:
                 request.body = body.replace(self.random_name, self.moniker)
@@ -119,7 +119,7 @@ class SingleValueReplacer(RecordingProcessor):
         return request
 
     def process_response(self, response):
-        if response['body']['string']:
+        if self.is_text_payload(response) and response['body']['string']:
             response['body']['string'] = response['body']['string'].replace(self.random_name,
                                                                             self.moniker)
 

--- a/src/azure_devtools/scenario_tests/recording_processors.py
+++ b/src/azure_devtools/scenario_tests/recording_processors.py
@@ -25,14 +25,8 @@ class RecordingProcessor(object):
 
     @classmethod
     def is_text_payload(cls, entity):
-        text_content_list = ['application/json', 'application/xml', 'text/html']
-        headers = getattr(entity, 'headers', None)
-        if headers is None:
-            headers = entity.get('headers')
-        if headers:
-            content_type = str(headers.get('content-type', None))
-            return bool([x for x in text_content_list if x in content_type])
-        return True
+        from .utilities import is_text_payload
+        return is_text_payload(entity)
 
 
 class SubscriptionRecordingProcessor(RecordingProcessor):
@@ -131,8 +125,7 @@ class BinaryResponseBodyProcessor(RecordingProcessor):
         if not self.is_text_payload(response):
             import base64
             if response['body']['string']:
-                # response['body']['string'] = base64.b64decode(response['body']['string']).decode('utf8')
-                response['body']['string'] = response['body']['string'].decode('latin1')
+                response['body']['string'] = base64.b64encode(response['body']['string'])
 
         return response
 
@@ -145,8 +138,7 @@ class BinaryResponseBodyFixer(RecordingProcessor):
 
             body = response['body']['string']
             if body:
-                #response['body']['string'] = base64.b64encode(body.decode('utf8'))
-                response['body']['string'] = body.decode('utf8').encode('latin1')
+                response['body']['string'] = base64.b64decode(body)
 
         return response
 

--- a/src/azure_devtools/scenario_tests/recording_processors.py
+++ b/src/azure_devtools/scenario_tests/recording_processors.py
@@ -141,14 +141,13 @@ class AccessTokenReplacer(RecordingProcessor):
         self._replacement = replacement
 
     def process_response(self, response):
-        if is_text_payload(response):
-            import json
-            try:
-                body = json.loads(response['body']['string'])
-                body['access_token'] = self._replacement
-            except (KeyError, ValueError):
-                return response
-            response['body']['string'] = json.dumps(body)
+        import json
+        try:
+            body = json.loads(response['body']['string'])
+            body['access_token'] = self._replacement
+        except (KeyError, ValueError):
+            return response
+        response['body']['string'] = json.dumps(body)
         return response
 
 

--- a/src/azure_devtools/scenario_tests/recording_processors.py
+++ b/src/azure_devtools/scenario_tests/recording_processors.py
@@ -88,7 +88,7 @@ class LargeResponseBodyProcessor(RecordingProcessor):
 
                 if is_json_payload(response):
                     from .preparers import AllowLargeResponse  # pylint: disable=cyclic-import
-                    raise ValueError("The json response body exceeds the default limit of '{}'kb. Use '@{}' "
+                    raise ValueError("The json response body exceeds the default limit of {}kb. Use '@{}' "
                                      "on your test method to increase the limit or update test logics to avoid "
                                      "big payloads".format(self._max_response_body, AllowLargeResponse.__name__))
 

--- a/src/azure_devtools/scenario_tests/tests/test_recording_processor.py
+++ b/src/azure_devtools/scenario_tests/tests/test_recording_processor.py
@@ -78,6 +78,7 @@ class TestRecordingProcessors(unittest.TestCase):
             mock_request = mock.Mock()
             mock_request.uri = template.format(mock_sub_id)
             mock_request.body = self._mock_subscription_request_body(mock_sub_id)
+            mock_request.headers = {'content-type': 'application/json'}
 
             rp.process_request(mock_request)
             self.assertEqual(mock_request.uri, template.format(replaced_subscription_id))
@@ -106,7 +107,8 @@ class TestRecordingProcessors(unittest.TestCase):
             mock_response = dict({'body': {}})
             mock_response['body']['string'] = template.format(mock_sub_id)
             mock_response['headers'] = {'Location': [location_header_template.format(mock_sub_id)],
-                                        'azure-asyncoperation': [asyncoperation_header_template.format(mock_sub_id)]}
+                                        'azure-asyncoperation': [asyncoperation_header_template.format(mock_sub_id)],
+                                        'content-type': ['application/json']}
             rp.process_response(mock_response)
             self.assertEqual(mock_response['body']['string'], template.format(replaced_subscription_id))
 

--- a/src/azure_devtools/scenario_tests/tests/test_recording_processor.py
+++ b/src/azure_devtools/scenario_tests/tests/test_recording_processor.py
@@ -116,3 +116,26 @@ class TestRecordingProcessors(unittest.TestCase):
                                      [location_header_template.format(replaced_subscription_id)])
             self.assertSequenceEqual(mock_response['headers']['azure-asyncoperation'],
                                      [asyncoperation_header_template.format(replaced_subscription_id)])
+
+
+    def test_recording_processor_skip_body_on_unrecognized_content_type(self):
+        location_header_template = 'https://graph.windows.net/{}/directoryObjects/' \
+                                   'f604c53a-aa21-44d5-a41f-c1ef0b5304bd/Microsoft.DirectoryServices.Application'
+        replaced_subscription_id = str(uuid.uuid4())
+        rp = SubscriptionRecordingProcessor(replaced_subscription_id)
+
+        mock_sub_id = str(uuid.uuid4())
+        mock_response = dict({'body': {}})
+        mock_response['body']['string'] = mock_sub_id
+        mock_response['headers'] = {
+            'Location': [location_header_template.format(mock_sub_id)],
+            'content-type': ['application/foo']
+        }
+
+        # action
+        rp.process_response(mock_response)
+
+        # assert
+        self.assertEqual(mock_response['body']['string'], mock_sub_id)  # body unchanged
+        self.assertEqual(mock_response['headers']['Location'],
+                         [location_header_template.format(replaced_subscription_id)])  # header changed

--- a/src/azure_devtools/scenario_tests/tests/test_utilities.py
+++ b/src/azure_devtools/scenario_tests/tests/test_utilities.py
@@ -5,7 +5,8 @@
 
 import unittest
 import mock
-from azure_devtools.scenario_tests.utilities import create_random_name, get_sha1_hash, is_text_payload
+from azure_devtools.scenario_tests.utilities import (create_random_name, get_sha1_hash,
+                                                     is_text_payload, is_json_payload)
 
 
 class TestUtilityFunctions(unittest.TestCase):
@@ -101,3 +102,17 @@ William Shakespeare
 
         http_entity.headers = None  # default to text mode if there is no header
         self.assertTrue(is_text_payload(http_entity))
+
+    def test_json_payload(self):
+        http_entity = mock.MagicMock()
+        headers = {}
+        http_entity.headers = headers
+
+        headers['content-type'] = 'APPLICATION/JSON; charset=utf-8'
+        self.assertTrue(is_json_payload(http_entity))
+
+        headers['content-type'] = 'application/json; charset=utf-8'
+        self.assertTrue(is_json_payload(http_entity))
+
+        headers['content-type'] = 'application/xml; charset=utf-8'
+        self.assertFalse(is_json_payload(http_entity))

--- a/src/azure_devtools/scenario_tests/tests/test_utilities.py
+++ b/src/azure_devtools/scenario_tests/tests/test_utilities.py
@@ -4,7 +4,8 @@
 # --------------------------------------------------------------------------------------------
 
 import unittest
-from azure_devtools.scenario_tests.utilities import create_random_name, get_sha1_hash
+import mock
+from azure_devtools.scenario_tests.utilities import create_random_name, get_sha1_hash, is_text_payload
 
 
 class TestUtilityFunctions(unittest.TestCase):
@@ -80,3 +81,23 @@ William Shakespeare
             f.seek(0)
             hash_value = get_sha1_hash(f.name)
             self.assertEqual('6487bbdbd848686338d729e6076da1a795d1ae747642bf906469c6ccd9e642f9', hash_value)
+
+    def test_text_payload(self):
+        http_entity = mock.MagicMock()
+        headers = {}
+        http_entity.headers = headers
+
+        headers['content-type'] = 'foo/'
+        self.assertFalse(is_text_payload(http_entity))
+
+        headers['content-type'] = 'text/html; charset=utf-8'
+        self.assertTrue(is_text_payload(http_entity))
+
+        headers['content-type'] = 'APPLICATION/JSON; charset=utf-8'
+        self.assertTrue(is_text_payload(http_entity))
+
+        headers['content-type'] = 'APPLICATION/xml'
+        self.assertTrue(is_text_payload(http_entity))
+
+        http_entity.headers = None  # default to text mode if there is no header
+        self.assertTrue(is_text_payload(http_entity))

--- a/src/azure_devtools/scenario_tests/utilities.py
+++ b/src/azure_devtools/scenario_tests/utilities.py
@@ -45,7 +45,7 @@ def is_text_payload(entity):
         headers = entity.get('headers')
 
     if headers:
-        # content-type is an array from response, convert to string first for keyword match  
+        # content-type is an array from response, convert to string first for keyword match
         content_type = str(headers.get('content-type', None))
         return bool([x for x in text_content_list if x in content_type])
     return True

--- a/src/azure_devtools/scenario_tests/utilities.py
+++ b/src/azure_devtools/scenario_tests/utilities.py
@@ -34,3 +34,15 @@ def get_sha1_hash(file_path):
             sha1.update(data)
 
     return sha1.hexdigest()
+
+
+def is_text_payload(entity):
+    text_content_list = ['application/json', 'application/xml', 'text/html']
+    headers = getattr(entity, 'headers', None)
+    if headers is None:
+        headers = entity.get('headers')
+    if headers:
+        # content-type is an array from response, convert to string first for keyword match  
+        content_type = str(headers.get('content-type', None))
+        return bool([x for x in text_content_list if x in content_type])
+    return True

--- a/src/azure_devtools/scenario_tests/utilities.py
+++ b/src/azure_devtools/scenario_tests/utilities.py
@@ -36,19 +36,30 @@ def get_sha1_hash(file_path):
     return sha1.hexdigest()
 
 
-def is_text_payload(entity):
-    text_content_list = ['application/json', 'application/xml', 'text/']
-
+def _get_content_type(entity):
     # 'headers' is a field of 'request', but it is a dict-key in 'response'
     headers = getattr(entity, 'headers', None)
     if headers is None:
         headers = entity.get('headers')
 
+    content_type = None
     if headers:
         content_type = headers.get('content-type', None)
         if content_type:
             # content-type could an array from response, let us extract it out
             content_type = content_type[0] if isinstance(content_type, list) else content_type
             content_type = content_type.split(";")[0].lower()
-            return any(content_type.startswith(x) for x in text_content_list)
+    return content_type
+
+
+def is_text_payload(entity):
+    text_content_list = ['application/json', 'application/xml', 'text/', 'application/test-content']
+
+    content_type = _get_content_type(entity)
+    if content_type:
+        return any(content_type.startswith(x) for x in text_content_list)
     return True
+
+
+def is_json_payload(entity):
+    return _get_content_type(entity) == 'application/json'

--- a/src/azure_devtools/scenario_tests/utilities.py
+++ b/src/azure_devtools/scenario_tests/utilities.py
@@ -37,7 +37,7 @@ def get_sha1_hash(file_path):
 
 
 def is_text_payload(entity):
-    text_content_list = ['application/json', 'application/xml', 'text/html']
+    text_content_list = ['application/json', 'application/xml', 'text/']
 
     # 'headers' is a field of 'request', but it is a dict-key in 'response'
     headers = getattr(entity, 'headers', None)
@@ -45,7 +45,10 @@ def is_text_payload(entity):
         headers = entity.get('headers')
 
     if headers:
-        # content-type is an array from response, convert to string first for keyword match
-        content_type = str(headers.get('content-type', None))
-        return bool([x for x in text_content_list if x in content_type])
+        content_type = headers.get('content-type', None)
+        if content_type:
+            # content-type could an array from response, let us extract it out
+            content_type = content_type[0] if isinstance(content_type, list) else content_type
+            content_type = content_type.split(";")[0].lower()
+            return any(content_type.startswith(x) for x in text_content_list)
     return True

--- a/src/azure_devtools/scenario_tests/utilities.py
+++ b/src/azure_devtools/scenario_tests/utilities.py
@@ -38,9 +38,12 @@ def get_sha1_hash(file_path):
 
 def is_text_payload(entity):
     text_content_list = ['application/json', 'application/xml', 'text/html']
+
+    # 'headers' is a field of 'request', but it is a dict-key in 'response'
     headers = getattr(entity, 'headers', None)
     if headers is None:
         headers = entity.get('headers')
+
     if headers:
         # content-type is an array from response, convert to string first for keyword match  
         content_type = str(headers.get('content-type', None))


### PR DESCRIPTION
//cc: @troydai 
Quick notes:
-  Binary serialization is already handled at yaml level, which works just fine across Python 2 & 3. Sorry for the confusion I might have caused
-  What need to happen is to have text mode recording/replay processors hand-off on binary payload
-  I took your suggestions by white-listing 3 content-types for text mode and treat the rest as binary.

Also, if you don't like to have same condition check at multiple code places, I can extract to a dedicated class say `BodyRewriter`. This adds a bit complexity. Your call :) 

I am adding more tests but you can start the review at the same time