### PR TITLE
AllowLargeResponse: opt out resource id random naming logic

### DIFF
--- a/src/azure_devtools/scenario_tests/preparers.py
+++ b/src/azure_devtools/scenario_tests/preparers.py
@@ -130,7 +130,8 @@ class SingleValueReplacer(RecordingProcessor):
 
 
 # Function wise, enabling large payload recording has nothing to do with resource preparers
-# We still base on it so that this decorator can chain with other preparers w/o too much hacks
+# We still base on it so that this decorator can acess test class's recording processors
+# and chain with other preparers w/o too much hacks
 class AllowLargeResponse(AbstractPreparer):
     def __init__(self, size_kb=1024):
         self.size_kb = size_kb
@@ -142,6 +143,10 @@ class AllowLargeResponse(AbstractPreparer):
                                 if isinstance(r, LargeResponseBodyProcessor)), None)
         if large_resp_body:
             large_resp_body._max_response_body = self.size_kb  # pylint: disable=protected-access
+
+    @property
+    def moniker(self):
+        return None
 
 # Utility
 


### PR DESCRIPTION
This is to opt-out the test resource counting logic used at playback. Any preparers not creating resources  should do the same thing; otherwise, the resource count mismatching from the recording mode will cause playback to fail due to unmatched request url.

//cc: @Troydai, @lmazuel  