### PR TITLE
remove x-ms-authorization-auxiliary header

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import io
 from setuptools import setup
 
 
-VERSION = "1.0.0"
+VERSION = "1.0.1"
 
 
 CLASSIFIERS = [

--- a/src/azure_devtools/scenario_tests/base.py
+++ b/src/azure_devtools/scenario_tests/base.py
@@ -81,7 +81,8 @@ class ReplayableTest(IntegrationTestBase):  # pylint: disable=too-many-instance-
         'x-ms-gateway-service-instanceid',
         'x-ms-ratelimit-remaining-tenant-reads',
         'x-ms-served-by',
-    ]
+        'x-ms-authorization-auxiliary'
+   ]
 
     def __init__(self,  # pylint: disable=too-many-arguments
                  method_name, config_file=None, recording_dir=None, recording_name=None, recording_processors=None,

--- a/src/azure_devtools/scenario_tests/base.py
+++ b/src/azure_devtools/scenario_tests/base.py
@@ -82,7 +82,7 @@ class ReplayableTest(IntegrationTestBase):  # pylint: disable=too-many-instance-
         'x-ms-ratelimit-remaining-tenant-reads',
         'x-ms-served-by',
         'x-ms-authorization-auxiliary'
-   ]
+    ]
 
     def __init__(self,  # pylint: disable=too-many-arguments
                  method_name, config_file=None, recording_dir=None, recording_name=None, recording_processors=None,


### PR DESCRIPTION
This header contains tokens used to access resource from other tenants for scenarios like 'vnet peering', 'vm image sharing'

//cc: @troydai