### PR TITLE
Add set_title method to DashboardCommentableObject

### DIFF
--- a/src/azure_devtools/ci_tools/github_tools.py
+++ b/src/azure_devtools/ci_tools/github_tools.py
@@ -333,6 +333,9 @@ class DashboardCommentableObject:  # pylint: disable=too-few-public-methods
         self._issue_or_pr = issue_or_pr
         self._header = header
 
+    def set_title(self, title):
+        pass
+
     def create_comment(self, text):
         """Mimic issue API, so we can use it everywhere.
         Return dashboard comment.

--- a/src/azure_devtools/ci_tools/tests/test_github_tools.py
+++ b/src/azure_devtools/ci_tools/tests/test_github_tools.py
@@ -132,6 +132,7 @@ class GithubTools(Framework.TestCase):
         assert error.comment is not None
         assert "Encountered an unknown error" in error.comment.body
 
+        dashboard.set_title("This does nothing but the method must exist")
         dashboard.create_comment("New text comment")
         after_size_2 = len(list(issue.get_comments()))
         assert after_size == after_size_2


### PR DESCRIPTION
Adding support for other types of CommentableObjects, which may have a the ability to set a title field. This one does not, so we need to add an empty method.