### PR TITLE
Restricted random bytes to only valid characters

### DIFF
--- a/src/azure_devtools/scenario_tests/base.py
+++ b/src/azure_devtools/scenario_tests/base.py
@@ -37,7 +37,7 @@ class IntegrationTestBase(unittest.TestCase):
 
         with open(path, mode='r+b') as f:
             if full_random:
-                chunk = os.urandom(1024)
+                chunk = str(map(lambda _: chr((128 - 32) * ord(_) / 255 + 32), os.urandom(1024)))
             else:
                 chunk = bytearray([0] * 1024)
             for _ in range(size_kb):

--- a/src/azure_devtools/scenario_tests/base.py
+++ b/src/azure_devtools/scenario_tests/base.py
@@ -37,9 +37,9 @@ class IntegrationTestBase(unittest.TestCase):
 
         with open(path, mode='r+b') as f:
             if full_random:
-                chunk = "".join(chr(int((126 - 32)
-                                    * (ord(_) if isinstance(_, str) else _)
-                                    / 255 + 32)) for _ in os.urandom(1024))
+                chunk = "".join(chr(int((126 - 32) \
+                                        * (ord(_) if isinstance(_, str) else _) \
+                                        / 255 + 32)) for _ in os.urandom(1024))
             else:
                 chunk = bytearray([0] * 1024)
             for _ in range(size_kb):

--- a/src/azure_devtools/scenario_tests/base.py
+++ b/src/azure_devtools/scenario_tests/base.py
@@ -37,8 +37,9 @@ class IntegrationTestBase(unittest.TestCase):
 
         with open(path, mode='r+b') as f:
             if full_random:
-                chunk = "".join(chr(int((126 - 32) * (ord(_) if isinstance(_, str) else _)
-                                        / 255 + 32)) for _ in os.urandom(1024))
+                chunk = "".join(chr(int((126 - 32)
+                                    * (ord(_) if isinstance(_, str) else _)
+                                    / 255 + 32)) for _ in os.urandom(1024))
             else:
                 chunk = bytearray([0] * 1024)
             for _ in range(size_kb):

--- a/src/azure_devtools/scenario_tests/base.py
+++ b/src/azure_devtools/scenario_tests/base.py
@@ -37,7 +37,7 @@ class IntegrationTestBase(unittest.TestCase):
 
         with open(path, mode='r+b') as f:
             if full_random:
-                chunk = "".join(chr((126 - 32) * ord(_) / 255 + 32) for _ in os.urandom(1024))
+                chunk = "".join(chr(int((126 - 32) * (ord(_) if type(_)==str else _) / 255 + 32)) for _ in os.urandom(1024))
             else:
                 chunk = bytearray([0] * 1024)
             for _ in range(size_kb):

--- a/src/azure_devtools/scenario_tests/base.py
+++ b/src/azure_devtools/scenario_tests/base.py
@@ -37,7 +37,8 @@ class IntegrationTestBase(unittest.TestCase):
 
         with open(path, mode='r+b') as f:
             if full_random:
-                chunk = "".join(chr(int((126 - 32) * (ord(_) if isinstance(_, str) else _) / 255 + 32)) for _ in os.urandom(1024))
+                chunk = "".join(chr(int((126 - 32) * (ord(_) if isinstance(_, str) else _)
+                                        / 255 + 32)) for _ in os.urandom(1024))
             else:
                 chunk = bytearray([0] * 1024)
             for _ in range(size_kb):

--- a/src/azure_devtools/scenario_tests/base.py
+++ b/src/azure_devtools/scenario_tests/base.py
@@ -37,7 +37,7 @@ class IntegrationTestBase(unittest.TestCase):
 
         with open(path, mode='r+b') as f:
             if full_random:
-                chunk = "".join(chr(int((126 - 32) * (ord(_) if type(_)==str else _) / 255 + 32)) for _ in os.urandom(1024))
+                chunk = "".join(chr(int((126 - 32) * (ord(_) if isinstance(_, str) else _) / 255 + 32)) for _ in os.urandom(1024))
             else:
                 chunk = bytearray([0] * 1024)
             for _ in range(size_kb):

--- a/src/azure_devtools/scenario_tests/base.py
+++ b/src/azure_devtools/scenario_tests/base.py
@@ -37,9 +37,10 @@ class IntegrationTestBase(unittest.TestCase):
 
         with open(path, mode='r+b') as f:
             if full_random:
-                chunk = "".join(chr(int((126 - 32) \
+                chunk = bytearray("".join(chr(int((126 - 32) \
                                         * (ord(_) if isinstance(_, str) else _) \
-                                        / 255 + 32)) for _ in os.urandom(1024))
+                                        / 255 + 32)) for _ in os.urandom(1024)),
+                                  'utf-8')
             else:
                 chunk = bytearray([0] * 1024)
             for _ in range(size_kb):

--- a/src/azure_devtools/scenario_tests/base.py
+++ b/src/azure_devtools/scenario_tests/base.py
@@ -37,7 +37,7 @@ class IntegrationTestBase(unittest.TestCase):
 
         with open(path, mode='r+b') as f:
             if full_random:
-                chunk = str(map(lambda _: chr((128 - 32) * ord(_) / 255 + 32), os.urandom(1024)))
+                chunk = "".join(chr((126 - 32) * ord(_) / 255 + 32) for _ in os.urandom(1024))
             else:
                 chunk = bytearray([0] * 1024)
             for _ in range(size_kb):


### PR DESCRIPTION
Fixes issue #36 
Generated bytes are rescaled to fall in the "universally" valid character range (32-126)
