### PR TITLE
Fix bug in SingleValueReplacer

### DIFF
--- a/src/azure_devtools/scenario_tests/preparers.py
+++ b/src/azure_devtools/scenario_tests/preparers.py
@@ -105,7 +105,7 @@ class SingleValueReplacer(RecordingProcessor):
                                               quote_plus(self.moniker))
 
         if is_text_payload(request) and request.body:
-            body = str(request.body)
+            body = str(request.body, 'utf-8') if isinstance(request.body, bytes) else str(request.body)
             if self.random_name in body:
                 request.body = body.replace(self.random_name, self.moniker)
 


### PR DESCRIPTION
SingleValueReplacer.process_request properly decodes request.body if its type is byte.

Current implementation of process_request plays poorly with [vcr.request.body setter](https://github.com/kevin1024/vcrpy/blob/master/vcr/request.py#L39) as it encodes strings back to bytes. 

The following assumes python 3.

```
\>>> bytes("foo", 'utf-8')
b'foo'
\>>> str(bytes("foo", 'utf-8'))
"b'foo'"

`simply casting the bytes with string returns the string repr of the byte.`
`This is not a byte type.`

\>>> str(bytes("foo", 'utf-8'), 'utf-8')
'foo'

`decodes byte into string`

\>>> str(bytes("foo", 'utf-8')).encode('utf-8')
b"b'foo'"
`byte contents includes byte literal repr,`

`this is what happens in request.body's setter because of incorrect value`

\>>> str(bytes("foo", 'utf-8'), 'utf-8').encode('utf-8')
b'foo'

`proper byte contents`
```

cc: @lmazuel 

See this [line](https://github.com/Azure/azure-cli/pull/9431/files#diff-7143a381d10b8397c1a7490bf6ebaea7R177) in https://github.com/Azure/azure-cli/pull/9431

