### PR TITLE
Don't record requests to AAD OAuth2 v2.0 endpoint

### DIFF
--- a/src/azure_devtools/scenario_tests/recording_processors.py
+++ b/src/azure_devtools/scenario_tests/recording_processors.py
@@ -129,8 +129,9 @@ class OAuthRequestResponsesFilter(RecordingProcessor):
     def process_request(self, request):
         # filter request like:
         # GET https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/token
+        # POST https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/v2.0/token
         import re
-        if not re.match('https://login.microsoftonline.com/([^/]+)/oauth2/token', request.uri):
+        if not re.match('https://login.microsoftonline.com/([^/]+)/oauth2(?:/v2.0)?/token', request.uri):
             return request
         return None
 


### PR DESCRIPTION
`OAuthRequestResponsesFilter` prevents recording of requests to AAD's v1 endpoint. This ensures requests to the v2.0 endpoint are similarly not recorded.

cc @lmazuel