### PR TITLE
fix "\" in sub problem

### DIFF
--- a/src/azure_devtools/scenario_tests/recording_processors.py
+++ b/src/azure_devtools/scenario_tests/recording_processors.py
@@ -60,6 +60,12 @@ class SubscriptionRecordingProcessor(RecordingProcessor):
                         r'https://\1/{}'.format(self._replacement),
                         retval,
                         flags=re.IGNORECASE)
+
+        # subscription presents in private dns is abnormal
+        retval = re.sub(r'\\/(subscriptions)\\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}',
+                        r'\\/\1\\/{}'.format(self._replacement),
+                        retval,
+                        flags=re.IGNORECASE)
         return retval
 
 

--- a/src/azure_devtools/scenario_tests/tests/test_recording_processor.py
+++ b/src/azure_devtools/scenario_tests/tests/test_recording_processor.py
@@ -93,7 +93,9 @@ class TestRecordingProcessors(unittest.TestCase):
         body_templates = ['https://management.azure.com/subscriptions/{}/providers/Microsoft.ContainerRegistry/'
                           'checkNameAvailability?api-version=2017-03-01',
                           'https://graph.Windows.net/{}/applications?api-version=1.6',
-                          "{{'scope':'/subscriptions/{}', 'another_data':'/Microsoft.Something'}}"]
+                          "{{'scope':'/subscriptions/{}', 'another_data':'/Microsoft.Something'}}",
+                          'https://management.azure.com\\/subscriptions\\/{}\\/providers\\/'
+                          'Microsoft.ContainerRegistry\\/checkNameAvailability?api-version=2017-03-01']
 
         location_header_template = 'https://graph.windows.net/{}/directoryObjects/' \
                                    'f604c53a-aa21-44d5-a41f-c1ef0b5304bd/Microsoft.DirectoryServices.Application'


### PR DESCRIPTION
The id field in the response from **private dns server** contains special character `\`, such as the following example `\/subscriptions\/eb87f233-893a-4f0f-8c55-7b4f67b1d097\/`. SubscriptionRecordingProcessor would fail and cause Azure CLI error when we run the recording tests.