### PR TITLE
Hide Microsoft.Management managementGroups uuid 

### DIFF
--- a/src/azure_devtools/scenario_tests/recording_processors.py
+++ b/src/azure_devtools/scenario_tests/recording_processors.py
@@ -66,6 +66,13 @@ class SubscriptionRecordingProcessor(RecordingProcessor):
                         r'\\/\1\\/{}'.format(self._replacement),
                         retval,
                         flags=re.IGNORECASE)
+                        
+        # Microsoft.Management managementGroups presents in all api call
+        retval = re.sub('/(managementGroups)/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}',
+                        r'/\1/{}'.format(self._replacement),
+                        val,
+                        flags=re.IGNORECASE)
+
         return retval
 
 

--- a/src/azure_devtools/scenario_tests/recording_processors.py
+++ b/src/azure_devtools/scenario_tests/recording_processors.py
@@ -66,11 +66,11 @@ class SubscriptionRecordingProcessor(RecordingProcessor):
                         r'\\/\1\\/{}'.format(self._replacement),
                         retval,
                         flags=re.IGNORECASE)
-                        
+
         # Microsoft.Management managementGroups presents in all api call
         retval = re.sub('/(managementGroups)/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}',
                         r'/\1/{}'.format(self._replacement),
-                        val,
+                        retval,
                         flags=re.IGNORECASE)
 
         return retval


### PR DESCRIPTION
Why:
In the Azure CLI PR: https://github.com/Azure/azure-cli/pull/18637
we have a path match issue due to the non-hiding UUID in the recording file. 
https://dev.azure.com/azure-sdk/public/_build/results?buildId=1003149&view=logs&j=15e5eb7c-cf66-5b91-00a2-db9b11b5e0f9&t=845fa2ee-a602-59f5-4e4c-07ee6d0283b9&l=4087
```
   except CannotOverwriteExistingCassetteException as ex:
>           raise AssertionError(ex)
E           AssertionError: Can't overwrite existing cassette ('/home/vsts/work/1/s/src/azure-cli/azure/cli/command_modules/sql/tests/latest/recordings/test_sql_db_sensitivity_classifications.yaml') in your current record mode ('once').
E           No match for the request (<Request (GET) https://management.azure.com/providers/Microsoft.Management/managementGroups/00000000-0000-0000-0000-000000000000/providers/Microsoft.Security/informationProtectionPolicies/effective?api-version=2017-08-01-preview>) was found.
E           Found 1 similar requests with 1 different matcher(s) :
E           
E           1 - (<Request (GET) https://management.azure.com/providers/Microsoft.Management/managementGroups/72f988bf-86f1-41af-91ab-2d7cd011db47/providers/Microsoft.Security/informationProtectionPolicies/effective?api-version=2017-08-01-preview>).
E           Matchers succeeded : ['method', 'scheme', 'host', 'port', '_custom_request_query_matcher']
E           Matchers failed :
E           path - assertion failure :
E           /providers/Microsoft.Management/managementGroups/00000000-0000-0000-0000-000000000000/providers/Microsoft.Security/informationProtectionPolicies/effective != /providers/Microsoft.Management/managementGroups/72f988bf-86f1-41af-91ab-2d7cd011db47/providers/Microsoft.Security/informationProtectionPolicies/effective
```

How:
After investigation, I found the issue above is due to the missing hide filter of `Microsoft.Management/managementGroups`. In this PR, I add them into the `SubscriptionRecordingProcessor` class. 

The goal of this PR is to unblock the stuck pipeline of https://github.com/Azure/azure-cli/pull/18637. I will leave the refactor work to CLI team.  